### PR TITLE
Check "As TL" for jss

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ props => ({
 | Package | As Object | As TL | SSR | RN Support | Agnostic | Dynamic | Babel plugins | Bindings |
 |:-----------------:|:-------------:|:------------------------:|:--------------------:|----------------------|--------------------|-------------|---------------|----------|
 | [fela](https://github.com/rofrischmann/fela/) | ✅ |  | ✅ | ✅ | ✅ | ✅ |  | [react-fela](http://fela.js.org/docs/guides/UsageWithReact.html) [native-fela](http://fela.js.org/docs/guides/UsageWithReactNative.html) [preact-fela](http://fela.js.org/docs/guides/UsageWithPreact.html) [inferno-fela](http://fela.js.org/docs/guides/UsageWithInferno.html) |
-| [jss](https://github.com/cssinjs/jss) | ✅ |  | ✅ |  | ✅ | ✅ |  | [react-jss](https://github.com/cssinjs/react-jss) [styled-jss](https://github.com/cssinjs/styled-jss) |
+| [jss](https://github.com/cssinjs/jss) | ✅ | ✅ | ✅ |  | ✅ | ✅ | ✅ | [react-jss](https://github.com/cssinjs/react-jss) [styled-jss](https://github.com/cssinjs/styled-jss) |
 | [rockey](https://github.com/tuchk4/rockey) |  | ✅ |  |  | ✅ | ✅ |  | [rockey-react](https://github.com/tuchk4/rockey/tree/master/packages/rockey-react) |
 | [styled-components](https://github.com/styled-components/styled-components) |  | ✅ | ✅ | ✅ |  | ✅ | ✅ |  |
 | [aphrodite](https://github.com/Khan/aphrodite) | ✅ |  | ✅ |  | ✅ |  |  |  |


### PR DESCRIPTION
There is [babel-plugin-styled-jss](https://github.com/lttb/babel-plugin-styled-jss), that allows to use TL for styled-jss too like:

```jsx
const Button = styled.button`
  padding: 10;
  color: ${({color}) => color}
`
```

So we need to add more information about this plugin in `styled-jss` docs.